### PR TITLE
Update 083-wesley-george_en.markdown

### DIFF
--- a/web/markdown/talks/083-wesley-george_en.markdown
+++ b/web/markdown/talks/083-wesley-george_en.markdown
@@ -1,6 +1,6 @@
 ---
 pk: 83
-title: Databases 201: the power of the relational algebra powers and limits of the ORM
+title: Databases 201: the power of the relational algebra and limits of the ORM
 kind: talk
 speakers: Wesley George
 date: 2016-11-12


### PR DESCRIPTION
Received an email from Wes asking that the title of their talk be updated.

> Hi Ryan,
> I submitted my talk with an error in the title :(
> It currently reads "Databases 201: the power of the relational algebra powers and limits of the ORM"
> I wanted it to read "Databases 201: the power of the relational algebra and limits of the ORM"
> (the second power shouldn't be there)
> (I see it posted here https://2016.pycon.ca/en/schedule/083-wesley-george/)
> Is it possible to get that title revised?
> W.
